### PR TITLE
Improved exceptions

### DIFF
--- a/bin/importTractography
+++ b/bin/importTractography
@@ -18,6 +18,13 @@
 import os
 import karawun
 import argparse
+import sys
+
+
+def exception_handler(exception_type, exception, traceback):
+    # All your trace are belong to us!
+    # your format
+    print ("Exception handler: %s - %s" %(exception_type.__name__, exception))
 
 
 def is_readable_file(parser, arg):
@@ -62,6 +69,11 @@ parser.add_argument("-l", "--label-files", nargs="+",
                     required=False,
                     help="One or more nifti label image files")
                     
+parser.add_argument("-v", "--verbose",
+                    action='store_true',
+                    required=False,
+                    help="verbose errors, python traceback")
+
 
 def run_cli(args):
     try:
@@ -74,6 +86,12 @@ def run_cli(args):
         print("One of the label images is not derived from any of the raw images")
     except karawun.MissingUIDList:
         print("A UID list is required iternally somewhere - this error shouldn't happen")
+
+
+
 if __name__ == '__main__':
     args=parser.parse_args()
+    if not args.verbose:
+        sys.excepthook = exception_handler
+
     run_cli(args)

--- a/karawun/karawun.py
+++ b/karawun/karawun.py
@@ -83,13 +83,6 @@ class RawToLabelImMismatch(Error):
    """Raised when one of the label images doesn't match any of the raw"""
    pass
 
-def exception_handler(exception_type, exception, traceback):
-    # All your trace are belong to us!
-    # your format
-    print ("Exception handler: %s - %s" %(exception_type.__name__, exception))
-
-sys.excepthook = exception_handler
-
 # mrtrix tckfile stuff
 # converts the MIF datatypes
 # Bit    bitwise data


### PR DESCRIPTION
More useful reporting on files that caused errors.

Configurable exception handling - by default the traceback isn't provided.

Allowing images only (no tract files)