### PR TITLE
Numpy dep

### DIFF
--- a/karawun/karawun.py
+++ b/karawun/karawun.py
@@ -1081,7 +1081,7 @@ def sitk_nifti_to_dicom(niftifile, dicomfile, dcmprefix, outdir,
 
         # Finally - pixel data
         P = sitk.GetArrayFromImage(image_slice)
-        thisslice.PixelData = P.tostring()
+        thisslice.PixelData = P.tobytes()
         fname = dcmprefix + "_" + format(i, "04") + ".dcm"
         fname = os.path.join(outdir, fname)
         pydi.filewriter.dcmwrite(fname, thisslice,
@@ -1241,7 +1241,7 @@ def mrtrix2surf(tck):
     # coordinate transform between mrtrix/nifti and dicom
     tf = np.array([-1, 0, 0, 0, -1, 0, 0, 0, 1])
     tf = tf.reshape(3, 3)
-    streamlines_dc = [np.array(tf * np.matrix(h)) for h in
+    streamlines_dc = [np.array(tf @ np.array(h)) for h in
                       tck['tracks']]
     points_dc = [np.r_[0:x.shape[1]] + 1 for x in streamlines_dc]
 
@@ -1322,7 +1322,7 @@ def mk_surface_sequence(coords, indexes, chk):
     def onePtIdxList(idxs):
         PL = pydi.Dataset()
         a = np.array(idxs, dtype=np.uint16)
-        PL.PrimitivePointIndexList = a.tostring()
+        PL.PrimitivePointIndexList = a.tobytes()
         return PL
 
     j = [onePtIdxList(x) for x in indexes]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-numpy==1.13.0
+numpy
 pydicom==1.3
 SimpleITK==1.2.0
 pip

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='richard.beare@mcri.edu.au',
     description=('DICOM image, segmgmentation image and fibre object converter'),
     long_description=(LONG_DESCRIPTION),
-    install_requires=["numpy==1.13.0",
+    install_requires=["numpy>=1.13.0",
                       "pydicom==1.3",
                       "SimpleITK==1.2.0"],
     entry_points={'console_scripts': ['importTractography = karawun.commandline:import_tractography_cl']}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ LONG_DESCRIPTION = \
 
 setup(
     name='karawun',
-    version='0.2.0.1',
+    version='0.2.0.2',
     packages=['karawun'],
     python_requires='>=3.6',
     package_dir={'karawun': 'karawun'},

--- a/tests/test_karawun.py
+++ b/tests/test_karawun.py
@@ -26,6 +26,7 @@ import hashlib
 import json
 
 import karawun.karawun
+from pathlib import Path, PurePosixPath
 
 # pytest tests/
 
@@ -72,6 +73,7 @@ def get_all_sha512(location):
             shalist = [get_sha512(f) for f in thesefiles]
             # Remove the location component
             relfiles = [os.path.relpath(f, location) for f in thesefiles]
+            relfiles = [str(PurePosixPath(Path(f))) for f in relfiles]
             z = zip(relfiles, shalist)
             shadict.update(dict(z))
 


### PR DESCRIPTION
Removed explicit numpy dependency, because it wasn't readily available under windows.
Responded to deprecation warnings from numpy
Changed test to use posix paths as keys so they work under windows.